### PR TITLE
feat(devops): add BASEPATH support to deployment scripts

### DIFF
--- a/env-backup.sh
+++ b/env-backup.sh
@@ -21,6 +21,7 @@ ENV_FILES=(
     "apps/web/.env"
     "apps/web/.env.production"
     "apps/web/.env.development"
+    "apps/bff/src/main/resources/serviceAccountKey.json"
 )
 
 backup() {


### PR DESCRIPTION
## Summary
- Add BASEPATH environment variable support to deployment scripts
- Enable flexible deployment to different environments (local/VPS)

## Changes
- `env-backup.sh`: Add `serviceAccountKey.json` to backup targets
- `front.sh`: Use BASEPATH for frontend deployment directory
- `back.sh`: Use BASEPATH for env-file path and pass to docker compose

## Usage
```bash
# Default (BASEPATH=/mydata)
./front.sh
./back.sh bff

# Custom path (e.g., VPS with /mydata2)
BASEPATH=/mydata2 ./front.sh
BASEPATH=/mydata2 ./back.sh bff order-service
```

## Test plan
- [x] `./env-backup.sh list` shows serviceAccountKey.json
- [x] `./env-backup.sh backup` works correctly
- [x] BASEPATH variable is respected in front.sh
- [x] BASEPATH variable is respected in back.sh with env-file