### PR TITLE
feat(devops): add BASEPATH support to front.sh and back.sh

### DIFF
--- a/back.sh
+++ b/back.sh
@@ -6,6 +6,10 @@ set -euo pipefail
 # Set default for iTerm2 variable if not set (prevents unbound variable error)
 export ITERM2_SQUELCH_MARK="${ITERM2_SQUELCH_MARK:-0}"
 
+# BASEPATH設定（デフォルト: /mydata）
+export BASEPATH="${BASEPATH:-/mydata}"
+ENV_FILE="${BASEPATH}/nginx/apps-env/ec-demo/platform/docker/demo/.env"
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR"
 
@@ -59,10 +63,18 @@ if [[ ${#services[@]} -eq 0 ]]; then
 fi
 
 echo "Services to rebuild: ${services[*]}"
+echo "BASEPATH: $BASEPATH"
 
 cd "$SCRIPT_DIR/platform/docker"
 COMPOSE_FILE="demo/docker-compose-demo-app.yml"
 
-docker compose -f "$COMPOSE_FILE" up -d --build "${services[@]}"
+# env-fileが存在する場合は使用
+if [[ -f "$ENV_FILE" ]]; then
+  echo "Using env-file: $ENV_FILE"
+  docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" up -d --build "${services[@]}"
+else
+  echo "Warning: env-file not found: $ENV_FILE"
+  docker compose -f "$COMPOSE_FILE" up -d --build "${services[@]}"
+fi
 
 echo "Selected backend services redeployed successfully."

--- a/front.sh
+++ b/front.sh
@@ -3,11 +3,16 @@
 # Exit on error
 set -e
 
+# BASEPATH設定（デフォルト: /mydata）
+BASEPATH="${BASEPATH:-/mydata}"
+FRONTEND_DIR="${BASEPATH}/nginx/html/ec-demo"
+
 #source ~/.bashrc
 export VOLTA_HOME="$HOME/.volta"
 export PATH="$VOLTA_HOME/bin:$PATH"
 echo "node version: $(node -v)"
 echo "npm version: $(npm -v)"
+echo "BASEPATH: $BASEPATH"
 
 echo "Starting build process for frontend..."
 
@@ -28,11 +33,11 @@ pnpm run build -- --mode production
 
 # Create target directory if it doesn't exist
 echo "Creating target directory if it doesn't exist..."
-rm -rf /mydata/nginx/html/ec-demo
-mkdir -p /mydata/nginx/html/ec-demo
+rm -rf "$FRONTEND_DIR"
+mkdir -p "$FRONTEND_DIR"
 
 # Copy the built assets to the target directory
-echo "Copying built assets to /mydata/nginx/html/ec-demo..."
-cp -r dist/* /mydata/nginx/html/ec-demo/
+echo "Copying built assets to $FRONTEND_DIR..."
+cp -r dist/* "$FRONTEND_DIR/"
 
 echo "Build and deployment completed successfully!"


### PR DESCRIPTION
## Summary
- Add BASEPATH environment variable support to deployment scripts
- Enable flexible deployment to different environments (local/VPS)

## Changes
- `front.sh`: Use BASEPATH for frontend deployment directory (`${BASEPATH}/nginx/html/ec-demo`)
- `back.sh`: Use BASEPATH for env-file path and pass to docker compose

## Usage
```bash
# Default (BASEPATH=/mydata)
./front.sh
./back.sh bff

# Custom path (e.g., VPS with /mydata2)
BASEPATH=/mydata2 ./front.sh
BASEPATH=/mydata2 ./back.sh bff order-service
```

## Test plan
- [x] BASEPATH variable is respected in front.sh
- [x] BASEPATH variable is respected in back.sh with env-file
- [x] Fallback works when env-file doesn't exist