### PR TITLE
feat(devops): BASEPATH support, env-backup.sh, payment service port fix

### DIFF
--- a/apps/web/src/views/PaymentDetailView.vue
+++ b/apps/web/src/views/PaymentDetailView.vue
@@ -513,6 +513,20 @@ async function fetchQr(): Promise<void> {
       return
     }
 
+    if (res.status === 409) {
+      const data = await res.json().catch(() => ({}))
+      const status = String((data as Record<string, unknown>).status || '').toUpperCase()
+      console.log('⚠️ Order already in terminal state, status:', status)
+      if (status === 'PAID') {
+        finalizeSuccess()
+      } else if (status === 'PAYMENT_FAILED' || status === 'FAILED') {
+        const msg = String((data as Record<string, unknown>).message || '支払いに失敗しました。')
+        paymentError.value = { code: 'PAYMENT_FAILED', message: msg }
+        hasFinalized.value = true
+      }
+      return
+    }
+
     if (!res.ok) {
       console.log('❌ Failed to fetch QR code, status:', res.status)
       return

--- a/env-backup.sh
+++ b/env-backup.sh
@@ -11,6 +11,11 @@ set -e
 # パス設定（スクリプトの場所を基準に相対パス）
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$SCRIPT_DIR"
+# ~/.bashrc を読み込んで BASEPATH などの環境変数を取得
+if [[ -f "$HOME/.bashrc" ]]; then
+    # shellcheck source=/dev/null
+    source "$HOME/.bashrc"
+fi
 BASEPATH="${BASEPATH:-/Users/wangjw/Dev/_Env/_demo/seata-mode}"
 BACKUP_DIR="${BASEPATH}/nginx/apps-env/ec-demo"
 


### PR DESCRIPTION
## 概要

payment-service のポートミス修正と、BASEPATH対応・env-backup.sh の改善をまとめたPRです。

## 変更内容

### fix: payment-service port mismatch
- `/mydata2/env/ec-demo-payment-service.env` の `SERVER_PORT=8090` → `SERVER_PORT=8084` に修正
- order-service から payment-service への接続が `Connection refused` になり、Sagaが補償されて注文が `CANCELLED` になっていた問題を解消

### fix(web): handle 409 Conflict in QR code fetch
- 注文が既に終了状態（PAID/CANCELLED）の際に QR コード取得で409が返った場合のフロントエンド処理を追加

### feat(devops): env-backup.sh の追加・改善
- `env-backup.sh` を新規追加（.env ファイルのバックアップ/復元スクリプト）
- `serviceAccountKey.json` をバックアップ対象に追加
- バックアップ前に `~/.bashrc` を source して `BASEPATH` を自動取得

### feat(devops): BASEPATH support
- `front.sh` / `back.sh` に BASEPATH サポートを追加

## 動作確認

- payment-service を port 8084 で起動確認
- order-service → payment-service 接続確認（Connection refused 解消）
- `env-backup.sh backup` で `/mydata2/nginx/apps-env/ec-demo` へバックアップ成功確認

## 影響サービス

- `ec-demo-payment-service` (port fix)
- `ec-demo-order-service` (downstream URL)
- `apps/web` (409 handling)
- `env-backup.sh` (devops tooling)
