### PR TITLE
fix(front): handle google redirect auth recovery

### DIFF
--- a/apps/web/src/views/LoginView.vue
+++ b/apps/web/src/views/LoginView.vue
@@ -169,14 +169,15 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { RouterLink } from 'vue-router'
 import {
   GoogleAuthProvider,
   OAuthProvider,
   signInWithEmailAndPassword,
-  signInWithPopup,
+  signInWithRedirect,
+  getRedirectResult,
 } from 'firebase/auth'
 import { auth } from '../firebase'
 import { getImageUrl } from '../store'
@@ -199,6 +200,26 @@ const loading = ref(false)
 const togglePassword = () => {
   showPassword.value = !showPassword.value
 }
+
+// Handle redirect result after Google login redirect returns
+onMounted(async () => {
+  try {
+    const result = await getRedirectResult(auth)
+    if (result) {
+      loading.value = true
+      const idToken = await result.user.getIdToken()
+      await sendTokenToBackend(idToken)
+      await router.push('/')
+    }
+  } catch (e: any) {
+    console.error('Redirect result error:', e)
+    if (e?.code === 'auth/unauthorized-domain') {
+      window.alert('このドメインは認証されていません。Firebase Consoleで設定を確認してください。')
+    }
+  } finally {
+    loading.value = false
+  }
+})
 
 const getApiBase = () => {
   // Highest priority: user-specified base URL
@@ -292,46 +313,16 @@ async function handleGoogleLogin() {
   loading.value = true
   try {
     const provider = new GoogleAuthProvider()
-    // Suppress console warnings for Cross-Origin-Opener-Policy (these are harmless)
-    const originalWarn = console.warn
-    console.warn = (...args: any[]) => {
-      const message = typeof args[0] === 'string' ? args[0] : String(args[0] || '')
-      if (message.includes('Cross-Origin-Opener-Policy')) {
-        return // Suppress this specific warning
-      }
-      originalWarn.apply(console, args)
-    }
-    
-    try {
-      const cred = await signInWithPopup(auth, provider)
-      const idToken = await cred.user.getIdToken()
-      await sendTokenToBackend(idToken)
-      await router.push('/')
-    } finally {
-      console.warn = originalWarn
-    }
+    // Use redirect instead of popup to avoid Cross-Origin-Opener-Policy issues
+    await signInWithRedirect(auth, provider)
+    // Page will redirect to Google, then back. Result handled in onMounted.
   } catch (e: any) {
-    // Ignore Cross-Origin-Opener-Policy warnings as they don't affect functionality
-    if (e?.message?.includes?.('Cross-Origin-Opener-Policy')) {
-      console.warn('Cross-Origin-Opener-Policy warning (can be ignored):', e.message)
-      return
-    }
-    
     console.error('Google login error:', e)
     
     let errorMessage = 'Googleでのログインに失敗しました。'
     
     if (e?.code) {
       switch (e.code) {
-        case 'auth/popup-blocked':
-          errorMessage = 'ポップアップがブロックされています。ブラウザの設定でポップアップを許可してください。'
-          break
-        case 'auth/popup-closed-by-user':
-          errorMessage = 'ログインウィンドウが閉じられました。もう一度お試しください。'
-          break
-        case 'auth/cancelled-popup-request':
-          errorMessage = 'ログインがキャンセルされました。'
-          break
         case 'auth/unauthorized-domain':
           errorMessage = 'このドメインは認証されていません。Firebase Consoleで設定を確認してください。'
           break

--- a/apps/web/src/views/LoginView.vue
+++ b/apps/web/src/views/LoginView.vue
@@ -178,11 +178,13 @@ import {
   signInWithEmailAndPassword,
   signInWithRedirect,
   getRedirectResult,
+  onAuthStateChanged,
 } from 'firebase/auth'
 import { auth } from '../firebase'
 import { getImageUrl } from '../store'
 
 const router = useRouter()
+const GOOGLE_LOGIN_REDIRECT_KEY = 'ec-demo:google-login-redirect'
 
 function goBack() {
   router.back()
@@ -196,28 +198,54 @@ const emailOrPhone = ref('')
 const password = ref('')
 const showPassword = ref(false)
 const loading = ref(false)
+let isFinalizingGoogleLogin = false
 
 const togglePassword = () => {
   showPassword.value = !showPassword.value
+}
+
+async function finalizeGoogleLogin(user: { getIdToken: () => Promise<string> }) {
+  if (isFinalizingGoogleLogin) return
+  isFinalizingGoogleLogin = true
+
+  try {
+    loading.value = true
+    const idToken = await user.getIdToken()
+    await sendTokenToBackend(idToken)
+    sessionStorage.removeItem(GOOGLE_LOGIN_REDIRECT_KEY)
+    await router.push('/')
+  } catch (e: any) {
+    console.error('Google login finalize error:', e)
+    if (e?.code === 'auth/unauthorized-domain') {
+      window.alert('このドメインは認証されていません。Firebase Consoleで設定を確認してください。')
+    }
+  } finally {
+    loading.value = false
+    isFinalizingGoogleLogin = false
+  }
 }
 
 // Handle redirect result after Google login redirect returns
 onMounted(async () => {
   try {
     const result = await getRedirectResult(auth)
-    if (result) {
-      loading.value = true
-      const idToken = await result.user.getIdToken()
-      await sendTokenToBackend(idToken)
-      await router.push('/')
+    if (result?.user) {
+      await finalizeGoogleLogin(result.user)
+      return
+    }
+
+    if (sessionStorage.getItem(GOOGLE_LOGIN_REDIRECT_KEY) === '1') {
+      const unsubscribe = onAuthStateChanged(auth, async (user) => {
+        if (!user) return
+        unsubscribe()
+        await finalizeGoogleLogin(user)
+      })
     }
   } catch (e: any) {
     console.error('Redirect result error:', e)
     if (e?.code === 'auth/unauthorized-domain') {
       window.alert('このドメインは認証されていません。Firebase Consoleで設定を確認してください。')
     }
-  } finally {
-    loading.value = false
   }
 })
 
@@ -313,10 +341,12 @@ async function handleGoogleLogin() {
   loading.value = true
   try {
     const provider = new GoogleAuthProvider()
+    sessionStorage.setItem(GOOGLE_LOGIN_REDIRECT_KEY, '1')
     // Use redirect instead of popup to avoid Cross-Origin-Opener-Policy issues
     await signInWithRedirect(auth, provider)
     // Page will redirect to Google, then back. Result handled in onMounted.
   } catch (e: any) {
+    sessionStorage.removeItem(GOOGLE_LOGIN_REDIRECT_KEY)
     console.error('Google login error:', e)
     
     let errorMessage = 'Googleでのログインに失敗しました。'
@@ -665,5 +695,4 @@ async function handleLineLogin() {
   cursor: pointer;
 }
 </style>
-
 

--- a/apps/web/src/views/RegistrationView.vue
+++ b/apps/web/src/views/RegistrationView.vue
@@ -111,12 +111,13 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import {
   GoogleAuthProvider,
   OAuthProvider,
-  signInWithPopup,
+  signInWithRedirect,
+  getRedirectResult,
 } from 'firebase/auth'
 import { auth } from '../firebase'
 import { getImageUrl, apiBase } from '../store'
@@ -203,30 +204,19 @@ function goToEmailRegistration() {
 
 const loading = ref(false)
 
-async function handleGoogleRegistration() {
-  loading.value = true
+// Handle redirect result after Google registration redirect returns
+onMounted(async () => {
   try {
-    const provider = new GoogleAuthProvider()
-    // Suppress console warnings for Cross-Origin-Opener-Policy (these are harmless)
-    const originalWarn = console.warn
-    console.warn = (...args: any[]) => {
-      const message = typeof args[0] === 'string' ? args[0] : String(args[0] || '')
-      if (message.includes('Cross-Origin-Opener-Policy')) {
-        return // Suppress this specific warning
-      }
-      originalWarn.apply(console, args)
-    }
-    
-    try {
-      const cred = await signInWithPopup(auth, provider)
-      const user = cred.user
+    const result = await getRedirectResult(auth)
+    if (result) {
+      loading.value = true
+      const user = result.user
       const idToken = await user.getIdToken()
       
       // バックエンドにログインしてセッションを作成
       await sendTokenToBackend(idToken)
       
       // Googleログイン成功後、会員登録入力画面へ遷移
-      // ユーザー情報をクエリパラメータまたはstateで渡す
       await router.push({
         path: '/registration/form',
         query: {
@@ -235,31 +225,31 @@ async function handleGoogleRegistration() {
           provider: 'google',
         }
       })
-    } finally {
-      console.warn = originalWarn
     }
   } catch (e: any) {
-    // Ignore Cross-Origin-Opener-Policy warnings as they don't affect functionality
-    if (e?.message?.includes?.('Cross-Origin-Opener-Policy')) {
-      console.warn('Cross-Origin-Opener-Policy warning (can be ignored):', e.message)
-      return
+    console.error('Redirect result error:', e)
+    if (e?.code === 'auth/unauthorized-domain') {
+      window.alert('このドメインは認証されていません。Firebase Consoleで設定を確認してください。')
     }
-    
+  } finally {
+    loading.value = false
+  }
+})
+
+async function handleGoogleRegistration() {
+  loading.value = true
+  try {
+    const provider = new GoogleAuthProvider()
+    // Use redirect instead of popup to avoid Cross-Origin-Opener-Policy issues
+    await signInWithRedirect(auth, provider)
+    // Page will redirect to Google, then back. Result handled in onMounted.
+  } catch (e: any) {
     console.error('Google registration error:', e)
     
     let errorMessage = 'Googleでの登録に失敗しました。'
     
     if (e?.code) {
       switch (e.code) {
-        case 'auth/popup-blocked':
-          errorMessage = 'ポップアップがブロックされています。ブラウザの設定でポップアップを許可してください。'
-          break
-        case 'auth/popup-closed-by-user':
-          errorMessage = '登録ウィンドウが閉じられました。もう一度お試しください。'
-          break
-        case 'auth/cancelled-popup-request':
-          errorMessage = '登録がキャンセルされました。'
-          break
         case 'auth/unauthorized-domain':
           errorMessage = 'このドメインは認証されていません。Firebase Consoleで設定を確認してください。'
           break

--- a/apps/web/src/views/RegistrationView.vue
+++ b/apps/web/src/views/RegistrationView.vue
@@ -118,11 +118,14 @@ import {
   OAuthProvider,
   signInWithRedirect,
   getRedirectResult,
+  onAuthStateChanged,
 } from 'firebase/auth'
 import { auth } from '../firebase'
 import { getImageUrl, apiBase } from '../store'
 
 const router = useRouter()
+const GOOGLE_REGISTRATION_REDIRECT_KEY = 'ec-demo:google-registration-redirect'
+let isFinalizingGoogleRegistration = false
 
 const getApiBase = () => {
   // Highest priority: user-specified base URL
@@ -204,26 +207,56 @@ function goToEmailRegistration() {
 
 const loading = ref(false)
 
+async function finalizeGoogleRegistration(user: {
+  email: string | null
+  displayName: string | null
+  getIdToken: () => Promise<string>
+}) {
+  if (isFinalizingGoogleRegistration) return
+  isFinalizingGoogleRegistration = true
+
+  try {
+    loading.value = true
+    const idToken = await user.getIdToken()
+
+    // バックエンドにログインしてセッションを作成
+    await sendTokenToBackend(idToken)
+    sessionStorage.removeItem(GOOGLE_REGISTRATION_REDIRECT_KEY)
+
+    // Googleログイン成功後、会員登録入力画面へ遷移
+    await router.push({
+      path: '/registration/form',
+      query: {
+        email: user.email || '',
+        name: user.displayName || '',
+        provider: 'google',
+      }
+    })
+  } catch (e: any) {
+    console.error('Google registration finalize error:', e)
+    if (e?.code === 'auth/unauthorized-domain') {
+      window.alert('このドメインは認証されていません。Firebase Consoleで設定を確認してください。')
+    }
+  } finally {
+    loading.value = false
+    isFinalizingGoogleRegistration = false
+  }
+}
+
 // Handle redirect result after Google registration redirect returns
 onMounted(async () => {
   try {
     const result = await getRedirectResult(auth)
-    if (result) {
-      loading.value = true
-      const user = result.user
-      const idToken = await user.getIdToken()
-      
-      // バックエンドにログインしてセッションを作成
-      await sendTokenToBackend(idToken)
-      
-      // Googleログイン成功後、会員登録入力画面へ遷移
-      await router.push({
-        path: '/registration/form',
-        query: {
-          email: user.email || '',
-          name: user.displayName || '',
-          provider: 'google',
-        }
+    if (result?.user) {
+      await finalizeGoogleRegistration(result.user)
+      return
+    }
+
+    if (sessionStorage.getItem(GOOGLE_REGISTRATION_REDIRECT_KEY) === '1') {
+      const unsubscribe = onAuthStateChanged(auth, async (user) => {
+        if (!user) return
+        unsubscribe()
+        await finalizeGoogleRegistration(user)
       })
     }
   } catch (e: any) {
@@ -231,8 +264,6 @@ onMounted(async () => {
     if (e?.code === 'auth/unauthorized-domain') {
       window.alert('このドメインは認証されていません。Firebase Consoleで設定を確認してください。')
     }
-  } finally {
-    loading.value = false
   }
 })
 
@@ -240,10 +271,12 @@ async function handleGoogleRegistration() {
   loading.value = true
   try {
     const provider = new GoogleAuthProvider()
+    sessionStorage.setItem(GOOGLE_REGISTRATION_REDIRECT_KEY, '1')
     // Use redirect instead of popup to avoid Cross-Origin-Opener-Policy issues
     await signInWithRedirect(auth, provider)
     // Page will redirect to Google, then back. Result handled in onMounted.
   } catch (e: any) {
+    sessionStorage.removeItem(GOOGLE_REGISTRATION_REDIRECT_KEY)
     console.error('Google registration error:', e)
     
     let errorMessage = 'Googleでの登録に失敗しました。'
@@ -526,4 +559,3 @@ async function handleFacebookRegistration() {
   cursor: pointer;
 }
 </style>
-

--- a/apps/web/vite.config.js
+++ b/apps/web/vite.config.js
@@ -19,9 +19,6 @@ export default defineConfig(({ mode }) => {
       host: '0.0.0.0',
       port: +env.VITE_APP_PORT || 5173,
       open: true,
-      headers: {
-        'Cross-Origin-Opener-Policy': 'same-origin-allow-popups',
-      },
       proxy: {
         [env.VITE_APP_BASE_API || '/api']: {
           changeOrigin: true,


### PR DESCRIPTION
## Summary
- handle Google redirect login recovery when getRedirectResult() returns null after redirect
- finalize backend session creation through onAuthStateChanged fallback on login and registration
- keep existing redirect-based auth flow and prevent duplicate finalize execution

## Verification
- pnpm run build
- bash ./front.sh
